### PR TITLE
Integrate Posthog analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,11 @@ yarn dev
 pnpm dev
 # or
 bun dev
+```
+
+Create a `.env.local` file based on `.env.example` and add your PostHog key:
+
+```bash
+cp my-portfolio/.env.example my-portfolio/.env.local
+# then edit my-portfolio/.env.local
+```

--- a/my-portfolio/.env.example
+++ b/my-portfolio/.env.example
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_POSTHOG_KEY=
+NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com

--- a/my-portfolio/.gitignore
+++ b/my-portfolio/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/my-portfolio/package.json
+++ b/my-portfolio/package.json
@@ -21,7 +21,8 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-intersection-observer": "^9.5.3",
-    "tailwind-merge": "^2.0.0"
+    "tailwind-merge": "^2.0.0",
+    "posthog-js": "^1.75.0"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/my-portfolio/src/app/layout.tsx
+++ b/my-portfolio/src/app/layout.tsx
@@ -6,7 +6,6 @@ import Header from "@/components/Header";
 import { defaultMetadata } from "@/config/metadata";
 import { favicons } from "@/config/favicons";
 import { Suspense } from "react";
-import Script from "next/script";
 import Analytics from "@/components/Analytics";
 
 const inter = Inter({

--- a/my-portfolio/src/app/layout.tsx
+++ b/my-portfolio/src/app/layout.tsx
@@ -6,6 +6,8 @@ import Header from "@/components/Header";
 import { defaultMetadata } from "@/config/metadata";
 import { favicons } from "@/config/favicons";
 import { Suspense } from "react";
+import Script from "next/script";
+import Analytics from "@/components/Analytics";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -39,6 +41,7 @@ export default function RootLayout({
             {children}
           </main>
         </ThemeProvider>
+        <Analytics />
       </body>
     </html>
   );

--- a/my-portfolio/src/components/Analytics.tsx
+++ b/my-portfolio/src/components/Analytics.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useEffect } from "react";
+import { usePathname } from "next/navigation";
+import posthog from "posthog-js";
+
+export default function Analytics() {
+  const pathname = usePathname();
+
+  // initialize posthog once
+  useEffect(() => {
+    posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY || "", {
+      api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+      capture_pageview: false,
+      person_profiles: "identified_only",
+      defaults: "2025-05-24",
+    });
+  }, []);
+
+  // capture page load with some user info
+  useEffect(() => {
+    posthog.capture("page_loaded", {
+      path: pathname,
+      language: navigator.language,
+      userAgent: navigator.userAgent,
+    });
+    if (pathname.startsWith("/projects")) {
+      posthog.capture("section_view", { section: "projects" });
+    }
+  }, [pathname]);
+
+  // observe sections and important actions
+  useEffect(() => {
+    const sections = ["skills", "articles", "contact"];
+    const observers: IntersectionObserver[] = [];
+
+    sections.forEach((id) => {
+      const el = document.getElementById(id);
+      if (!el) return;
+      const obs = new IntersectionObserver((entries, observer) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            posthog.capture("section_view", { section: id });
+            observer.disconnect();
+          }
+        });
+      }, { threshold: 0.5 });
+      obs.observe(el);
+      observers.push(obs);
+    });
+
+    const projectsLink = document.querySelector('a[href="/projects"]');
+    const handleProjects = () => posthog.capture("section_view", { section: "projects" });
+    projectsLink?.addEventListener("click", handleProjects);
+
+    const emailLink = document.querySelector('a[href^="mailto:"]');
+    const handleEmail = () => posthog.capture("contact_email");
+    emailLink?.addEventListener("click", handleEmail);
+
+    const linkedinLink = document.querySelector('a[href*="linkedin.com"]');
+    const handleLinkedin = () => posthog.capture("contact_linkedin");
+    linkedinLink?.addEventListener("click", handleLinkedin);
+
+    return () => {
+      observers.forEach((o) => o.disconnect());
+      projectsLink?.removeEventListener("click", handleProjects);
+      emailLink?.removeEventListener("click", handleEmail);
+      linkedinLink?.removeEventListener("click", handleLinkedin);
+    };
+  }, []);
+
+  return null;
+}

--- a/my-portfolio/src/components/Analytics.tsx
+++ b/my-portfolio/src/components/Analytics.tsx
@@ -5,7 +5,7 @@ import { usePathname } from "next/navigation";
 import posthog from "posthog-js";
 
 export default function Analytics() {
-  const pathname = usePathname();
+  const pathname = usePathname() ?? "";
 
   // initialize posthog once
   useEffect(() => {


### PR DESCRIPTION
## Summary
- add Posthog snippet and analytics component
- track page and section views with Posthog

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f454e81708327abe02aff04a1c3b5