### PR TITLE
Update metadata to use profile photo for previews

### DIFF
--- a/my-portfolio/src/config/metadata.ts
+++ b/my-portfolio/src/config/metadata.ts
@@ -1,12 +1,13 @@
 import type { Metadata } from "next";
 
-const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "https://kauedelazzeri.com";
+const baseUrl =
+  process.env.NEXT_PUBLIC_BASE_URL || "https://kauedelazzeri.com";
 
 export const siteConfig = {
   name: "Kaue Delazzeri",
   description: "Product Manager with 4 years of experience in electric mobility, platform architecture, and online payments — focused on growth and data-driven strategy.",
   url: baseUrl,
-  ogImage: `${baseUrl}/og.jpg`,
+  ogImage: `${baseUrl}/images/profile-photo.jpg`,
 } as const;
 
 export const defaultMetadata: Metadata = {


### PR DESCRIPTION
## Summary
- use profile photo as the Open Graph preview image

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f99586bf48327a7f1b20f185aedce